### PR TITLE
Cleanup vivado project folder

### DIFF
--- a/hls-template/build_prj.tcl
+++ b/hls-template/build_prj.tcl
@@ -63,4 +63,6 @@ if {$opt(synth)} {
   }
 }
 
+file delete -force myproject_prj/solution1/.autopilot
+
 exit


### PR DESCRIPTION
This only removes the `.autopilot` directory, which is the largest. The reports remain.